### PR TITLE
Allow specifying snapshot identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-pdf-snapshot",
-  "version": "0.5.5",
+  "version": "0.5.7",
   "description": "Jest matcher for pdf comparison",
   "main": "src/index.js",
   "repository": "https://github.com/zeptometer/jest-pdf-snapshot.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-pdf-snapshot",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Jest matcher for pdf comparison",
   "main": "src/index.js",
   "repository": "https://github.com/zeptometer/jest-pdf-snapshot.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-pdf-snapshot",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Jest matcher for pdf comparison",
   "main": "src/index.js",
   "repository": "https://github.com/zeptometer/jest-pdf-snapshot.git",

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -21,6 +21,7 @@ function diffPdfToSnapshot({
   snapshotIdentifier,
   updateSnapshot,
   addSnapshot,
+  onlyUpdateIfDifferent,
 }, {
   isSamePdf = defaultIsSamePdf,
   generateDiff = defaultGenerateDiff,
@@ -34,19 +35,8 @@ function diffPdfToSnapshot({
 
   const snapshotPath = path.join(snapshotDir, `${snapshotIdentifier}.pdf`);
 
-  if (updateSnapshot) {
-    const snapshotFd = fs.openSync(snapshotPath, 'w');
-    fs.writeSync(snapshotFd, pdfBuffer);
-
-    return {
-      pass: true,
-      updated: true,
-      added: false,
-    };
-  }
-
   if (!fs.existsSync(snapshotPath)) {
-    if (addSnapshot) {
+    if (addSnapshot || updateSnapshot) {
       const snapshotFd = fs.openSync(snapshotPath, 'w');
       fs.writeSync(snapshotFd, pdfBuffer);
 
@@ -60,6 +50,17 @@ function diffPdfToSnapshot({
     return {
       pass: false,
       failureType: 'EmptySnapshot',
+    };
+  }
+
+  if (updateSnapshot && !onlyUpdateIfDifferent) {
+    const snapshotFd = fs.openSync(snapshotPath, 'w');
+    fs.writeSync(snapshotFd, pdfBuffer);
+
+    return {
+      pass: true,
+      updated: true,
+      added: false,
     };
   }
 
@@ -78,6 +79,17 @@ function diffPdfToSnapshot({
     generateDiff(tmpFile.name, snapshotPath, diffOutputPath);
 
     tmpFile.removeCallback();
+
+    if (updateSnapshot) {
+      const snapshotFd = fs.openSync(snapshotPath, 'w');
+      fs.writeSync(snapshotFd, pdfBuffer);
+
+      return {
+        pass: true,
+        updated: true,
+        added: false,
+      };
+    }
 
     return {
       pass: false,

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ function createSnapshotIdentifier({
 }
 
 // eslint-disable-next-line no-unused-vars
-function toMatchPdfSnapshot(received) {
+function toMatchPdfSnapshot(received, options) {
   const {
     testPath, currentTestName, snapshotState, isNot,
   } = this;
@@ -45,11 +45,12 @@ function toMatchPdfSnapshot(received) {
   // eslint-disable-next-line no-underscore-dangle
   initializeOrIncrementTestCounter(snapshotState._counters, currentTestName);
 
-  const snapshotIdentifier = createSnapshotIdentifier({
-    testPath,
-    currentTestName,
-    snapshotState,
-  });
+  const snapshotIdentifier = options && options.snapshotIdentifier
+    ? options.snapshotIdentifier : createSnapshotIdentifier({
+      testPath,
+      currentTestName,
+      snapshotState,
+    });
   // eslint-disable-next-line no-underscore-dangle
   const updateSnapshot = snapshotState._updateSnapshot === 'all';
   // eslint-disable-next-line no-underscore-dangle

--- a/src/index.js
+++ b/src/index.js
@@ -29,8 +29,15 @@ function createSnapshotIdentifier({
 // eslint-disable-next-line no-unused-vars
 function toMatchPdfSnapshot(received, options) {
   const {
-    testPath, currentTestName, snapshotState, isNot,
+    testPath, currentTestName, currentConcurrentTestName, snapshotState, isNot,
   } = this;
+
+  let testName;
+  if (currentConcurrentTestName) {
+    testName = currentConcurrentTestName();
+  } else {
+    testName = currentTestName;
+  }
 
   if (isNot) {
     throw new Error('Jest: `.not` cannot be used with `.toMatchPdfSnapshot()`.');
@@ -43,12 +50,12 @@ function toMatchPdfSnapshot(received, options) {
   }
 
   // eslint-disable-next-line no-underscore-dangle
-  initializeOrIncrementTestCounter(snapshotState._counters, currentTestName);
+  initializeOrIncrementTestCounter(snapshotState._counters, testName);
 
   const snapshotIdentifier = options && options.snapshotIdentifier
     ? options.snapshotIdentifier : createSnapshotIdentifier({
       testPath,
-      currentTestName,
+      currentTestName: testName,
       snapshotState,
     });
   // eslint-disable-next-line no-underscore-dangle

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ function createSnapshotIdentifier({
 }
 
 // eslint-disable-next-line no-unused-vars
-function toMatchPdfSnapshot(received, options) {
+function toMatchPdfSnapshot(received, options = {}) {
   const {
     testPath, currentTestName, currentConcurrentTestName, snapshotState, isNot,
   } = this;
@@ -52,7 +52,7 @@ function toMatchPdfSnapshot(received, options) {
   // eslint-disable-next-line no-underscore-dangle
   initializeOrIncrementTestCounter(snapshotState._counters, testName);
 
-  const snapshotIdentifier = options && options.snapshotIdentifier
+  const snapshotIdentifier = options.snapshotIdentifier
     ? options.snapshotIdentifier : createSnapshotIdentifier({
       testPath,
       currentTestName: testName,
@@ -69,6 +69,7 @@ function toMatchPdfSnapshot(received, options) {
     snapshotIdentifier,
     updateSnapshot,
     addSnapshot,
+    onlyUpdateIfDifferent: options.onlyUpdateIfDifferent || false,
   });
 
   const {


### PR DESCRIPTION
because sometimes the automatic snapshot identifier creates unwieldy names and also I had some issues where the counter was wonky (creating `-2` files even though there was only one expectation in the test).